### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/RealTreasury/personal-inventory-tracker/security/code-scanning/7](https://github.com/RealTreasury/personal-inventory-tracker/security/code-scanning/7)

To fix this problem, the workflow file should include an explicit `permissions` block to set GITHUB_TOKEN to the minimum required. Since the test job only checks out code, installs dependencies, and runs tests—actions that require only `contents: read` (to fetch the code), we can set `permissions: contents: read` at either the workflow or the job level. To follow least-privilege best practices and in line with the example, adding the block at the workflow (top/root) level right after the `name` field is sufficient and clear. No new packages or YAML features are required; just insert the minimal permissions specification near the top of `.github/workflows/test.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
